### PR TITLE
Copilotが日本語でレビューしてくれないときがあるので指示追加

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,7 @@
 
 <!-- for GitHub Copilot review rule -->
 <!--
+日本語でレビューしてください。
 レビューする際には、以下のprefix(接頭辞)を付けてください。
 [must] must fix
 [imo] in my opinion


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 要件・指示
- Copilotが日本語でレビューしてくれないときがある
- 「日本語でレビューしてください。」を追加すると日本語でレビューするようになることが多かったので追加

## やったこと
- 日本語でレビューしてくれないときがあるので指示を追加

## 動作確認
- 確認項目

### 確認環境
- 単体
    - [ ] Curl or テストコードで動作チェック
- 組み込み
    - [ ] ローカル
    - [ ] Dev
    - [ ] Production

## 特記事項
- イレギュラーな対応など

## 関連 PR
- 関連する他 PR（他リポジトリのものも）

## 期日
- mm/dd (曜日) までにリリースしたい（みてもらいたい）


## レビューについて

必ず日本語でレビューすること。

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)を付けてください。
[must] must fix
[imo] in my opinion
[nits] nitpick
[ask] question
[fyi] for your information
-->
<!-- for GitHub Copilot review rule -->

<!-- I want to review in Japanese. -->
